### PR TITLE
Use APIdia JavaDoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ var text = TextFormatter.of("blue text here, ", TrueColor.of(50, 50, 255))
 System.out.println(text);
 ```
 
-Javadocs for the latest stable version are provided online [here](https://darvil82.github.io/java-terminal-text-formatter/).
+Javadocs for the latest stable version are provided online [here](https://apidia.net/mvn/com.darvil/terminal-text-formatter/).
 
 
 ## Installation


### PR DESCRIPTION
I like [APIdia](https://github.com/APIdia-net/apidia.net)'s rendering of JavaDoc. It now also supports also this project. See https://apidia.net/mvn/com.darvil/terminal-text-formatter.

I think, this could be linked to in the README.md of this project, too.

(Refs https://github.com/APIdia-net/apidia.net/issues/12)